### PR TITLE
Folders can now be renamed

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,3 +1,4 @@
+import GlobalEvents from '@/components/global-events';
 import ContextMenu from '@/system/context-menu';
 import Desktop from '@/system/file-system/desktop';
 import Taskbar from '@/system/taskbar';
@@ -15,6 +16,7 @@ const App = (): React.ReactElement => {
       </Wallpaper>
       <MaximizedWindowHeader />
       <ContextMenu />
+      <GlobalEvents />
     </>
   );
 };

--- a/src/apps/solitaire/store/index.ts
+++ b/src/apps/solitaire/store/index.ts
@@ -905,7 +905,6 @@ const useSolitaireStore = create<SolitaireState>()(
       reset: () => {
         set((state) => {
           state.isGameInProgress = false;
-
           localStorage.removeItem('solitaire-store');
         });
       },

--- a/src/components/global-events.tsx
+++ b/src/components/global-events.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect, useCallback } from 'react';
+
+import useFileSystemStore from '@/system/file-system/store';
+
+const GlobalEvents = (): React.ReactElement => {
+  const clearRenaming = useFileSystemStore((state) => state.clearRenaming);
+
+  const clearRenamingOnContextMenu = useCallback(() => {
+    clearRenaming();
+  }, [clearRenaming]);
+
+  useEffect(() => {
+    window.addEventListener('contextmenu', clearRenamingOnContextMenu);
+    return () => {
+      window.removeEventListener('contextmenu', clearRenamingOnContextMenu);
+    };
+  }, [clearRenamingOnContextMenu]);
+
+  return <></>;
+};
+
+export default GlobalEvents;

--- a/src/globals.css
+++ b/src/globals.css
@@ -60,3 +60,8 @@ input[type='radio']:focus {
 .preserve-3d {
   transform-style: preserve-3d;
 }
+
+::selection {
+  background: #0226ed;
+  color: #fff;
+}

--- a/src/system/file-system/components/icon.tsx
+++ b/src/system/file-system/components/icon.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, ReactElement, useMemo, useEffect } from 'react';
+import React, { Suspense, ReactElement, useMemo, useEffect, useRef, useState } from 'react';
 
 import UseKeyPresses from '@/hooks/use-key-presses';
 import UseIconDrag from '@/system/file-system/hooks/use-icon-drag';
@@ -46,10 +46,14 @@ const FileExplorerIcon: React.FC<IconProps> = ({
   const getIconAtPosition = useFileSystemStore((state) => state.getIconAtPosition);
   const getIconTransformScale = useFileSystemStore((state) => state.getIconTransformScale);
   const setTransformScale = useFileSystemStore((state) => state.setIconTransformScale);
+  const clearRenaming = useFileSystemStore((state) => state.clearRenaming);
+  const renameEntry = useFileSystemStore((state) => state.renameEntry);
   const isDragOverFolder = useFileSystemStore((state) => state.getIsDragOverFolder());
   const isIconSelected = useFileSystemStore((state) => state.getIsIconSelected(entry.id));
   const isIconDragging = useFileSystemStore((state) => state.getIsIconDragging(entry.id));
   const dragInitiatorId = useFileSystemStore((state) => state.getDragInitiatorId());
+  const isRenaming = useFileSystemStore((state) => state.getIsRenaming(entry.id));
+  const shouldUpdateName = useFileSystemStore((state) => state.shouldUpdateName);
 
   const { isShiftPressed } = UseKeyPresses();
 
@@ -57,6 +61,58 @@ const FileExplorerIcon: React.FC<IconProps> = ({
     UseIconSelect(entry, selectRectVisible);
   const { handleDragStart, handleMouseMove, handleMouseUp } = UseIconDrag(entry, dropTargetId);
   const LazyIcon = useMemo(() => getLazyIcon(entry.icon!), [entry.icon]);
+
+  /*
+   ********************************
+   *           Renaming           *
+   ********************************
+   */
+  const [renameInputValue, setRenameInputValue] = useState(entry.name);
+  const renameInputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto focus and select text when renaming
+  useEffect(() => {
+    if (isRenaming && renameInputRef.current) {
+      renameInputRef.current.focus();
+      renameInputRef.current.select();
+    }
+  }, [isRenaming]);
+
+  // Stop the renaming when pressing Enter or Escape
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        (e.key === 'Enter' || e.key === 'Escape') &&
+        document.activeElement === renameInputRef.current
+      ) {
+        e.preventDefault();
+        clearRenaming();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [clearRenaming]);
+
+  // Update the store once the name is changed
+  // We're using local state only while isRenaming is true, and when
+  // clearRenaming is called, it sets a global flag, which the below
+  // useEffect will listen for. Why the roundabout? Because renaming
+  // can be cancelled from various other places, so it's best to just
+  // use the observer pattern here.
+  useEffect(() => {
+    if (shouldUpdateName) {
+      if (renameInputValue === '') {
+        setRenameInputValue(entry.name);
+      } else {
+        const newName = renameEntry(entry.id, renameInputValue);
+        if (newName) {
+          setRenameInputValue(newName);
+        }
+      }
+    }
+  }, [shouldUpdateName, entry.id, renameInputValue, renameEntry, entry.name]);
 
   /*
    ***********************************
@@ -148,10 +204,11 @@ const FileExplorerIcon: React.FC<IconProps> = ({
   ]);
 
   /*
-   **************************************
-   *      Dropping on folder icons      *
-   **************************************
+   ********************************
+   *       Icon Drop Targets      *
+   ********************************
    */
+  // Get the icon at the location of the drop guide
   const dropTargetIcon = useMemo((): FileSystemEntry | null => {
     let targetOrigin = parentPosition;
     let iconPosition = dropGuidePos;
@@ -178,8 +235,10 @@ const FileExplorerIcon: React.FC<IconProps> = ({
     getWindowPosition,
   ]);
 
+  // Checks if this instance is the one that started the drag
   const isDragInitiator = dragInitiatorId === entry.id;
 
+  // When a dropTargetIs defined, update the state to keep track of the id
   useEffect(() => {
     if (isIconDragging && isDragInitiator && dropTargetIcon?.id !== entry.id) {
       setDropTargetIconId(dropTargetIcon?.id ?? null);
@@ -193,121 +252,156 @@ const FileExplorerIcon: React.FC<IconProps> = ({
     setDropTargetIconId,
   ]);
 
+  // Conditions for valid and invalid drops
   const isValidDrop = isDragInitiator && dropTargetIcon && dropTargetIcon.type === 'directory';
   const isInvalidDrop = isDragInitiator && dropTargetIcon && dropTargetIcon.type === 'file';
+
+  // This hides all the other drop guides when hovering over a folder.
+  // It's mostly for a cleaner UX
   const shouldHide = !isDragInitiator && isDragOverFolder;
 
   return (
-    <Suspense
-      fallback={
-        <></>
-        // <div
-        //   className="absolute size-[80px] animate-pulse bg-gray-500/10"
-        //   style={{
-        //     transform: `translate(${entry.iconPosition.x.toString()}px, ${entry.iconPosition.y.toString()}px)`,
-        //   }}
-        // />
-      }
-    >
-      <>
-        {/* Drop Preview */}
-        {isIconDragging && !shouldHide && (
-          <span
-            className={cn(
-              'border-black pointer-events-none absolute h-[88px] w-[80px] border-2 border-dashed transition-transform',
-              `duragion-${ICON_ANIMATION_DURATION.toString()}`,
-              isValidDrop && 'bg-green-500/10 border-green-700',
-              isInvalidDrop && 'bg-red-500/10 border-red-700',
-              // When any other non-initator hovers over any other icon, negative feedback
-              !isDragInitiator && dropTargetIcon && 'bg-red-500/10 border-red-700',
-            )}
-            style={{
-              transform: `
-                translate(${dropGuidePos.x.toString()}px, ${dropGuidePos.y.toString()}px)
-                translateZ(1px)
-              `,
-              zIndex: 50,
-            }}
-          />
-        )}
-
-        {/* File System Icon */}
-        <button
-          draggable
-          onDragStart={handleDragStart}
-          type="button"
-          data-id={`${entry.type}-icon`}
+    <>
+      {/* Drop Preview */}
+      {isIconDragging && !shouldHide && (
+        <span
           className={cn(
-            'w-[80px] h-[88px]',
-            'absolute px-2 rounded-md background-transparent cursor-default flex flex-col items-center focus:outline-none',
-            isIconSelected && 'bg-black/20',
-            !isIconDragging && 'transition-transform duragion 500',
-            !isIconSelected && !isAnyIconDragging && 'hover:bg-black/10',
-            isIconDragging && 'opacity-60',
+            'border-black pointer-events-none absolute h-[88px] w-[80px] border-2 border-dashed transition-transform',
+            `duragion-${ICON_ANIMATION_DURATION.toString()}`,
+            isValidDrop && 'bg-green-500/10 border-green-700',
+            isInvalidDrop && 'bg-red-500/10 border-red-700',
+            // When any other non-initator hovers over any other icon, negative feedback
+            !isDragInitiator && dropTargetIcon && 'bg-red-500/10 border-red-700',
           )}
           style={{
             transform: `
+                translate(${dropGuidePos.x.toString()}px, ${dropGuidePos.y.toString()}px)
+                translateZ(1px)
+              `,
+            zIndex: 50,
+          }}
+        />
+      )}
+
+      {/* File System Icon */}
+      <button
+        draggable={!isRenaming}
+        onDragStart={(event) => {
+          handleDragStart(event);
+        }}
+        type="button"
+        data-id={`${entry.type}-icon`}
+        className={cn(
+          'w-[80px] h-[88px]',
+          'absolute px-2 rounded-md background-transparent cursor-default flex flex-col items-center focus:outline-none',
+          isIconSelected && 'bg-black/20',
+          !isIconDragging && 'transition-transform duragion 500',
+          !isIconSelected && !isAnyIconDragging && 'hover:bg-black/10',
+          isIconDragging && 'opacity-60',
+        )}
+        style={{
+          transform: `
               translate(${entry.iconPosition.x.toString()}px, ${entry.iconPosition.y.toString()}px)
               scale(${isIconDragging ? '1.1' : getIconTransformScale(entry.id).toString()})
               ${isIconDragging ? 'translateZ(1px)' : ''}
             `,
-            pointerEvents: isIconDragging ? 'none' : 'auto',
-            zIndex: isIconDragging ? 50 : 0,
-          }}
-          onClick={(event) => {
-            event.stopPropagation();
-          }}
-          onMouseDown={(event: React.MouseEvent) => {
-            event.stopPropagation();
-            if (event.button === 2) return;
-            handleToggleSelect();
-            handleMouseDownSelect(event);
-            clearContextState();
-            if (entry.parentId === 'desktop') {
-              blurWindowFocus(true);
-            } else {
-              pushFocus(entry.parentId!);
-            }
-          }}
-          onMouseUp={(event: React.MouseEvent) => {
-            if (event.button === 2) return;
-            handleMouseUpSelect(event);
-          }}
-          onFocus={(event: React.FocusEvent) => {
-            event.stopPropagation();
-            if (isAnyIconDragging) return;
-            handleFocusSelect();
-          }}
-          onDoubleClick={() => {
-            openEntry(entry.id);
-          }}
-          onContextMenu={(event) => {
-            event.preventDefault();
-            const targetDataId = getEventTargetDataId(event);
-            if (targetDataId === `${entry.type}-icon`) {
-              const clickPosition = { x: event.clientX, y: event.clientY };
-              setContextState({
-                id: entry.id,
-                category: 'icon',
-                clickPosition,
-              });
-            }
-          }}
-        >
+          pointerEvents: isIconDragging ? 'none' : 'auto',
+          zIndex: isIconDragging ? 50 : 0,
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
+        onMouseDown={(event: React.MouseEvent) => {
+          event.stopPropagation();
+          if (event.button === 2) return;
+          handleToggleSelect();
+          handleMouseDownSelect(event);
+          clearContextState();
+          if (entry.parentId === 'desktop') {
+            blurWindowFocus(true);
+          } else {
+            pushFocus(entry.parentId!);
+          }
+        }}
+        onMouseUp={(event: React.MouseEvent) => {
+          if (event.button === 2 || isRenaming) return;
+          handleMouseUpSelect(event);
+        }}
+        onFocus={(event: React.FocusEvent) => {
+          event.stopPropagation();
+          if (isAnyIconDragging || isRenaming) return;
+          handleFocusSelect();
+        }}
+        onDoubleClick={() => {
+          if (isRenaming) return;
+          openEntry(entry.id);
+        }}
+        onContextMenu={(event) => {
+          event.preventDefault();
+          if (isRenaming) return;
+          const targetDataId = getEventTargetDataId(event);
+          if (targetDataId === `${entry.type}-icon`) {
+            const clickPosition = { x: event.clientX, y: event.clientY };
+            setContextState({
+              id: entry.id,
+              category: 'icon',
+              clickPosition,
+            });
+          }
+        }}
+      >
+        <Suspense fallback={null}>
           <LazyIcon
             className={cn('icon-shadow')}
             data-id={`${entry.type}-icon`}
             width={entry.iconSize ?? 64}
             height={entry.iconSize ?? 64}
             fill={entry.iconColor}
+            onMouseDown={() => {
+              clearRenaming();
+            }}
             onClick={(event) => {
               event.stopPropagation();
             }}
           />
-          <span className={cn('select-none text-base font-bold')}>{entry.name}</span>
-        </button>
-      </>
-    </Suspense>
+        </Suspense>
+        {!isRenaming && (
+          <textarea
+            maxLength={26}
+            disabled
+            className={cn(
+              'absolute resize-none overflow-visible text-base font-bold bg-transparent text-center',
+              'focus:outline-none',
+            )}
+            style={{
+              bottom: -20,
+              width: '105px',
+              overflowWrap: 'break-word',
+            }}
+            value={renameInputValue}
+          />
+        )}
+        {isRenaming && (
+          <textarea
+            ref={renameInputRef}
+            maxLength={26}
+            className={cn(
+              'absolute resize-none overflow-visible text-base font-bold bg-transparent text-center',
+              'focus:outline-none',
+            )}
+            style={{
+              bottom: -20,
+              width: '105px',
+              overflowWrap: 'break-word',
+            }}
+            value={renameInputValue}
+            onChange={(event) => {
+              setRenameInputValue(event.target.value);
+            }}
+          />
+        )}
+      </button>
+    </>
   );
 };
 

--- a/src/system/file-system/context-menu/index.ts
+++ b/src/system/file-system/context-menu/index.ts
@@ -13,11 +13,14 @@ const directoryContextMenuItems: ContextMenuItems = new Map([
         {
           callback: (entry) => {
             if (!entry) return;
-            useFileSystemStore.getState().createEntry({
+            const newEntryId = useFileSystemStore.getState().createEntry({
               parentId: entry.id,
               name: 'NewFolder',
               type: 'directory',
             });
+            if (newEntryId) {
+              useFileSystemStore.getState().setRenaming(newEntryId);
+            }
           },
         },
       ],
@@ -37,10 +40,10 @@ const directoryContextMenuItems: ContextMenuItems = new Map([
       [
         'Rename',
         {
-          callback: () => {
-            console.log('Rename');
+          callback: (entry) => {
+            if (!entry) return;
+            useFileSystemStore.getState().setRenaming(entry.id);
           },
-          disableCallback: () => true,
           bottomBorder: true,
         },
       ],

--- a/src/system/file-system/desktop/index.tsx
+++ b/src/system/file-system/desktop/index.tsx
@@ -13,6 +13,7 @@ const Desktop = (): React.ReactElement => {
   const setContextState = useFileSystemStore((state) => state.setContextState);
   const clearContextState = useFileSystemStore((state) => state.clearContextState);
   const setDropTargetId = useFileSystemStore((state) => state.setDropTargetId);
+  const clearRenaming = useFileSystemStore((state) => state.clearRenaming);
   const desktopChildren = useFileSystemStore((state) => state.getDirectory('desktop'));
   const desktopEntry = useFileSystemStore((state) => state.getEntry({ id: 'desktop' }));
   const dropTargetId = useFileSystemStore((state) => state.getDropTargetId());
@@ -63,6 +64,7 @@ const Desktop = (): React.ReactElement => {
             }
             blurWindowFocus(true);
             clearContextState();
+            clearRenaming();
           }
         }}
         onClick={(event) => {

--- a/src/system/file-system/directory/index.tsx
+++ b/src/system/file-system/directory/index.tsx
@@ -15,6 +15,7 @@ const Directory = ({ entry }: AppComponent): React.ReactElement => {
   const setContextState = useFileSystemStore((state) => state.setContextState);
   const clearContextState = useFileSystemStore((state) => state.clearContextState);
   const getWindowState = useFileSystemStore((state) => state.getWindowState);
+  const clearRenaming = useFileSystemStore((state) => state.clearRenaming);
   const dropTargetId = useFileSystemStore((state) => state.getDropTargetId());
   const isAnyIconDragging = useFileSystemStore((state) => state.getIsAnyIconDragging());
   const windowPosition = useFileSystemStore((state) => state.getWindowPosition(entry?.id ?? ''));
@@ -74,6 +75,7 @@ const Directory = ({ entry }: AppComponent): React.ReactElement => {
             }
             pushFocus(entry.id);
             clearContextState();
+            clearRenaming();
           }
         }}
         onClick={(event) => {

--- a/src/system/file-system/store/index.ts
+++ b/src/system/file-system/store/index.ts
@@ -1689,6 +1689,9 @@ const useFileSystemStore = create<FileSystemState>()(
 
         // Set icon scale to 1, to avoid animating in. I mostly want an abrupt drop, not a smooth transition here
         sourceEntry.iconTransformScale = 1;
+
+        // If the name of the entry already exists in the parent id, give the entry a unqiue name
+        sourceEntry.name = get().validateName(targetParentId, sourceEntry.name)!;
       });
     },
 

--- a/src/system/taskbar/components/taskbar-entry.tsx
+++ b/src/system/taskbar/components/taskbar-entry.tsx
@@ -14,7 +14,9 @@ const TaskbarEntry = ({ entry }: taskbarEntryProperties): JSX.Element => {
   const pushFocus = useFileSystemsStore((state) => state.pushFocus);
   const setContextState = useFileSystemsStore((state) => state.setContextState);
   const clearContextState = useFileSystemsStore((state) => state.clearContextState);
+  const clearRenaming = useFileSystemsStore((state) => state.clearRenaming);
   const windowState = useFileSystemsStore((state) => state.getWindowState(entry.id));
+  const name = useFileSystemsStore((state) => state.getName(entry.id));
   const isFocused = useFileSystemsStore((state) => state.getIsWindowFocused(entry.id));
   const isOpen = useFileSystemsStore((state) => state.getIsOpen(entry.id));
   const transformScale = useFileSystemsStore((state) => state.getTransformScale(entry.id));
@@ -81,6 +83,7 @@ const TaskbarEntry = ({ entry }: taskbarEntryProperties): JSX.Element => {
         setMouseDown(true);
 
         clearContextState();
+        clearRenaming();
       }}
       onMouseUp={() => {
         setButtonDown(false);
@@ -116,7 +119,7 @@ const TaskbarEntry = ({ entry }: taskbarEntryProperties): JSX.Element => {
       <Suspense fallback={<span className="size-8 animate-pulse rounded-md" />}>
         <LazyIcon width={32} height={32} fill="#fff" className="select-none" />
       </Suspense>
-      {entry.name}
+      {name}
     </button>
   );
 };

--- a/src/system/taskbar/index.tsx
+++ b/src/system/taskbar/index.tsx
@@ -10,6 +10,7 @@ const Taskbar = (): JSX.Element => {
   const getEntry = useFileSystemStore((state) => state.getEntry);
   const blurWindowFocus = useFileSystemStore((state) => state.blurWindowFocus);
   const clearContextState = useFileSystemStore((state) => state.clearContextState);
+  const clearRenaming = useFileSystemStore((state) => state.clearRenaming);
   const taskbarColor = '#FFAFAF';
   return (
     <footer
@@ -26,11 +27,13 @@ const Taskbar = (): JSX.Element => {
         event.preventDefault();
         if (getEventTargetDataId(event) === 'taskbar') {
           clearContextState();
+          clearRenaming();
         }
       }}
       onClick={() => {
         blurWindowFocus(true);
         clearContextState();
+        clearRenaming();
       }}
     >
       <nav style={{ backgroundColor: taskbarColor }} className="flex size-full gap-1 p-1 pl-8 pr-4">

--- a/src/system/window-system/components/window-header.tsx
+++ b/src/system/window-system/components/window-header.tsx
@@ -13,6 +13,7 @@ interface WindowHeaderProperties {
 const WindowHeader: React.FC<WindowHeaderProperties> = ({ entry }): ReactElement => {
   const isFocused = useFileSystemStore((state) => state.getIsWindowFocused(entry.id));
   const isOpen = useFileSystemStore((state) => state.getIsOpen(entry.id));
+  const name = useFileSystemStore((state) => state.getName(entry.id));
   const pushFocus = useFileSystemStore((state) => state.pushFocus);
   const toggleSizeToViewport = useFileSystemStore((state) => state.toggleSizeToViewport);
   const clearContextState = useFileSystemStore((state) => state.clearContextState);
@@ -80,7 +81,7 @@ const WindowHeader: React.FC<WindowHeaderProperties> = ({ entry }): ReactElement
         }}
       >
         <HeaderButtons entry={entry} />
-        <h1 className={cn(headerTextColor, 'cursor-default select-none')}>{entry.name}</h1>
+        <h1 className={cn(headerTextColor, 'cursor-default select-none')}>{name}</h1>
       </header>
     </>
   );


### PR DESCRIPTION
Folders can now be renamed. This can be done via the context menu or when creating a new folder. Names are also unique and will have an index appended to them if users attempt to rename them to an existing name or move a same-named folder to the same directory. 